### PR TITLE
Change the default of skip_final_default to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "kms_key_arn" {
 
 variable "skip_final_snapshot" {
   description = "Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created."
-  default     = "true"
+  default     = "false"
 }
 
 variable "tags" {


### PR DESCRIPTION
Most people don't know of this feature, and I think it's a good safety feature. If people accidentally delete their database, then they don't potentially lose data with this.