### PR TITLE
Terraform 0.12upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,10 @@ dist: trusty
 sudo: false
 
 before_install:
-  - curl -fSL "https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip" -o terraform.zip
+  - curl -fSL "https://releases.hashicorp.com/terraform/0.12.3/terraform_0.12.3_linux_amd64.zip" -o terraform.zip
   - sudo unzip terraform.zip -d /opt/terraform
   - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
   - rm -f terraform.zip
-  - curl -fSL https://github.com/wata727/tflint/releases/download/v0.7.0/tflint_linux_amd64.zip -o tflint.zip
-  - sudo unzip tflint.zip -d /opt/tflint
-  - sudo ln -s /opt/tflint/tflint /usr/bin/tflint
-  - rm -f tflint.zip
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 	@for d in $$(find . -type f -name '*.tf' -path "./modules/*" -not -path "**/.terraform/*" -exec dirname {} \; | sort -u); do \
 		cd $$d; \
 		terraform init -backend=false >> /dev/null; \
-		terraform validate -check-variables=false; \
+		terraform validate; \
 		if [ $$? -eq 1 ]; then \
 			echo "✗ terraform validate failed: $$d"; \
 			exit 1; \

--- a/examples/default/example.tf
+++ b/examples/default/example.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
   region = "eu-west-1"
 }
@@ -7,33 +11,34 @@ data "aws_vpc" "main" {
 }
 
 data "aws_subnet_ids" "main" {
-  vpc_id = "${data.aws_vpc.main.id}"
+  vpc_id = data.aws_vpc.main.id
 }
 
 module "rds" {
   source = "../../"
 
   name_prefix = "example"
-  username    = "<user>"
-  password    = "<pass>"
+  username    = "test"
+  password    = "SomePassword123"
   port        = "5000"
-  vpc_id      = "${data.aws_vpc.main.id}"
-  subnet_ids  = "${data.aws_subnet_ids.main.ids}"
+  vpc_id      = data.aws_vpc.main.id
+  subnet_ids  = data.aws_subnet_ids.main.ids
 
-  tags {
-    environment = "prod"
+  tags = {
+    environment = "dev"
     terraform   = "True"
   }
 }
 
 output "security_group_id" {
-  value = "${module.rds.security_group_id}"
+  value = module.rds.security_group_id
 }
 
 output "endpoint" {
-  value = "${module.rds.endpoint}"
+  value = module.rds.endpoint
 }
 
 output "port" {
-  value = "${module.rds.port}"
+  value = module.rds.port
 }
+

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ resource "random_string" "suffix" {
 }
 
 resource "aws_rds_cluster" "main" {
+  depends_on                   = ["aws_db_subnet_group.main"]
   cluster_identifier           = "${var.name_prefix}-cluster"
   database_name                = var.database_name
   master_username              = var.username

--- a/main.tf
+++ b/main.tf
@@ -94,4 +94,3 @@ resource "aws_security_group_rule" "egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   ipv6_cidr_blocks  = ["::/0"]
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,50 +3,51 @@
 # ------------------------------------------------------------------------------
 output "id" {
   description = "The RDS Cluster Identifier."
-  value       = "${aws_rds_cluster.main.id}"
+  value       = aws_rds_cluster.main.id
 }
 
 output "resource_id" {
   description = "The RDS Cluster Resource ID."
-  value       = "${aws_rds_cluster.main.cluster_resource_id}"
+  value       = aws_rds_cluster.main.cluster_resource_id
 }
 
 output "arn" {
   description = "Amazon Resource Name (ARN) of cluster."
-  value       = "${aws_rds_cluster.main.arn}"
+  value       = aws_rds_cluster.main.arn
 }
 
 output "security_group_id" {
   description = "The ID of the security group."
-  value       = "${aws_security_group.main.id}"
+  value       = aws_security_group.main.id
 }
 
 output "subnet_group_id" {
   description = "The db subnet group name."
-  value       = "${aws_db_subnet_group.main.id}"
+  value       = aws_db_subnet_group.main.id
 }
 
 output "subnet_group_arn" {
   description = "The ARN of the db subnet group."
-  value       = "${aws_db_subnet_group.main.arn}"
+  value       = aws_db_subnet_group.main.arn
 }
 
 output "endpoint" {
   description = "The DNS address of the RDS instance."
-  value       = "${aws_rds_cluster.main.endpoint}"
+  value       = aws_rds_cluster.main.endpoint
 }
 
 output "port" {
   description = "The database port."
-  value       = "${aws_rds_cluster.main.port}"
+  value       = aws_rds_cluster.main.port
 }
 
 output "username" {
   description = "The master username for the database."
-  value       = "${aws_rds_cluster.main.master_username}"
+  value       = aws_rds_cluster.main.master_username
 }
 
 output "database_name" {
   description = "Name for the automatically created database."
-  value       = "${aws_rds_cluster.main.database_name}"
+  value       = aws_rds_cluster.main.database_name
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "vpc_id" {
 
 variable "subnet_ids" {
   description = "A list of VPC subnet IDs."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "username" {
@@ -84,6 +84,7 @@ variable "performance_insights_enabled" {
 
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -3,10 +3,12 @@
 # ------------------------------------------------------------------------------
 variable "name_prefix" {
   description = "A prefix used for naming resources."
+  type        = string
 }
 
 variable "vpc_id" {
   description = "The VPC ID."
+  type        = string
 }
 
 variable "subnet_ids" {
@@ -16,70 +18,84 @@ variable "subnet_ids" {
 
 variable "username" {
   description = "Username for the master DB user."
+  type        = string
 }
 
 variable "password" {
   description = "Password for the master DB user."
+  type        = string
 }
 
 variable "database_name" {
   description = "Name for an automatically created database on cluster creation."
+  type        = string
   default     = "main"
 }
 
 variable "port" {
   description = "The port on which the DB accepts connections."
-  default     = "5439"
+  type        = number
+  default     = 5439
 }
 
 variable "engine" {
   description = "The name of the database engine to be used for this DB cluster."
+  type        = string
   default     = "aurora-postgresql"
 }
 
 variable "engine_version" {
   description = "The engine version to use."
+  type        = string
   default     = ""
 }
 
 variable "instance_type" {
   description = "The DB instance class to use."
+  type        = string
   default     = "db.r4.large"
 }
 
 variable "instance_count" {
   description = "Number of DB instances to provision for the cluster."
-  default     = "1"
+  type        = number
+  default     = 1
 }
 
 variable "publicly_accessible" {
   description = "Bool to control if instances is publicly accessible."
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "snapshot_identifier" {
   description = "Specifies whether or not to create this cluster from a snapshot."
+  type        = string
   default     = ""
 }
 
 variable "storage_encrypted" {
   description = "Specifies whether the DB cluster is encrypted."
-  default     = "true"
+  type        = bool
+  default     = true
 }
 
 variable "kms_key_arn" {
   description = "The ARN for the KMS encryption key. When specifying kms_key_id, storage_encrypted needs to be set to true."
+  type        = string
   default     = ""
 }
 
 variable "skip_final_snapshot" {
   description = "Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created."
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights is enabled or not."
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
No diff for the examples. Added `depends_on` to fix long standing issue with `terraform destroy` producing the following error:
>Cannot delete the subnet group 'example-subnet-group' because at least one database cluster: example-cluster is still using it.

Fixing the issue should not have any side effects :D 