### PR TITLE
Fix Warning Quoted references are deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "random_string" "suffix" {
 }
 
 resource "aws_rds_cluster" "main" {
-  depends_on                   = ["aws_db_subnet_group.main"]
+  depends_on                   = [aws_db_subnet_group.main]
   cluster_identifier           = "${var.name_prefix}-cluster"
   database_name                = var.database_name
   master_username              = var.username


### PR DESCRIPTION
```
Warning: Quoted references are deprecated

  on .terraform/modules/cpa.rds_settlement/telia-oss-terraform-aws-rds-cluster-d991514/main.tf line 13, in resource "aws_rds_cluster" "main":
  13:   depends_on                   = ["aws_db_subnet_group.main"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.
```