### PR TITLE
Add support for passing in iam_roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "aws_rds_cluster" "main" {
   skip_final_snapshot          = var.skip_final_snapshot
   storage_encrypted            = var.storage_encrypted
   kms_key_id                   = var.kms_key_arn
+  iam_roles                    = var.iam_roles
 
   tags = merge(
     var.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,8 @@ variable "tags" {
   default     = {}
 }
 
+variable "iam_roles" {
+  description = "(Optional) A List of ARNs for the IAM roles to associate to the RDS Cluster."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
Is also backwards compatible.

There is a problem: terraform-providers/terraform-provider-aws#9552
Adding the feature must be done using aws-cli or console. But then this resource is out of sync, but with allowing to pass in an iam_roles parameter, the resource is in sync again.

An alternative approach would be to add this instead:
`lifecycle { ignore_changes = [iam_roles] } `